### PR TITLE
Update geonames_importer.sh

### DIFF
--- a/geonames_importer.sh
+++ b/geonames_importer.sh
@@ -4,7 +4,7 @@
 dbhost="localhost"
 dbport=3306
 dbname="geonames"
-#dir=$( cd "$( dirname "$0" )" && pwd )
+dir=$(pwd)
 
 download_folder="`pwd`/download"
 
@@ -103,10 +103,6 @@ if [ -z $dbusername ]; then
     exit 1
 fi
 
-if [ -z $dbpassword ]; then
-    echo "No user password provided for accessing the database. Please write some value in parameter -p..."
-    exit 1
-fi
 
 echo "Database parameters being used..."
 echo "Orden: " $action


### PR DESCRIPTION
Fixing $dir variable that was not set but the script was relying on the value
Removing check of password (-p parameter) some mysql are running locally and do not require password to be set for the root user.
