### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-###Shell Script for importing geonames.org data dumps into a MySQL database.
+### Shell Script for importing geonames.org data dumps into a MySQL database.
 
 Please, visit the <a href="http://codigofuerte.github.com/GeoNames-MySQL-DataImport" target="_blank">project's web site</a> for a more detailed information.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
